### PR TITLE
Refactor/config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,14 @@ DB_PASSWORD=admin
 DB_NAME=postgres
 DB_SSLMODE=disable
 
-GO_ENV=local
+SERVER_NAME=ConDormHub
+SERVER_PORT=3069
+SERVER_ENV=local
+SERVER_MAX_BODY_LIMIT_MB=100
+SERVER_CORS_ALLOW_ORIGINS='http://localhost:3000, http://localhost:3069, https://www.condormhub.com'
+SERVER_CORS_ALLOW_METHODS='GET, POST, PATCH, DELETE, OPTIONS'
+SERVER_CORS_ALLOW_HEADERS='Origin, Content-Type, Accept, Authorization'
+SERVER_CORS_ALLOW_CREDENTIALS=true
 
 SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -3,30 +3,25 @@ package main
 import (
 	"fmt"
 
+	"github.com/PitiNarak/condormhub-backend/internals/config"
 	"github.com/PitiNarak/condormhub-backend/internals/core/domain"
 	"github.com/PitiNarak/condormhub-backend/internals/databases"
 
 	"github.com/gofiber/fiber/v2/log"
-	"github.com/joho/godotenv"
 )
 
 func main() {
-	err := godotenv.Load()
-	if err != nil {
-		log.Warnf("Warning: No .env file found")
-	}
+	config := config.Load()
 
-	db, err := databases.NewDatabaseConnection()
+	db, err := databases.NewDatabaseConnection(config.Database)
 	if err != nil {
 		log.Fatalf("Database connection failed: %v", err)
 	}
 
-	err = db.AutoMigrate(&domain.SampleLog{})
-	if err != nil {
-		log.Fatalf("Migration failed: %v", err)
-	}
-	err = db.AutoMigrate(&domain.User{})
-	if err != nil {
+	if err := db.AutoMigrate(
+		&domain.SampleLog{},
+		&domain.User{},
+	); err != nil {
 		log.Fatalf("Migration failed: %v", err)
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,23 +1,27 @@
 package main
 
 import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/PitiNarak/condormhub-backend/internals/config"
 	"github.com/PitiNarak/condormhub-backend/internals/databases"
 	"github.com/PitiNarak/condormhub-backend/internals/server"
 	"github.com/gofiber/fiber/v2/log"
-	"github.com/joho/godotenv"
 )
 
 func main() {
-	err := godotenv.Load()
-	if err != nil {
-		log.Warnf("Warning: No .env file found")
-	}
+	config := config.Load()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
 
-	db, err := databases.NewDatabaseConnection()
+	db, err := databases.NewDatabaseConnection(config.Database)
 	if err != nil {
 		log.Fatalf("Database connection failed: %v", err)
 	}
 
-	s := server.NewServer(db)
-	s.Start("3000")
+	s := server.NewServer(config.Server, config.SMTP, config.JWT, db)
+	s.Start(ctx, stop)
 }

--- a/internals/config/config.go
+++ b/internals/config/config.go
@@ -5,13 +5,17 @@ import (
 
 	"github.com/PitiNarak/condormhub-backend/internals/core/services"
 	"github.com/PitiNarak/condormhub-backend/internals/core/utils"
+	"github.com/PitiNarak/condormhub-backend/internals/databases"
+	"github.com/PitiNarak/condormhub-backend/internals/server"
 	"github.com/caarlos0/env/v11"
 	"github.com/joho/godotenv"
 )
 
 type AppConfig struct {
-	SMTP services.SMTPConfig `envPrefix:"SMTP_"`
-	JWT  utils.JWTConfig     `envPrefix:"JWT_"`
+	SMTP     services.SMTPConfig `envPrefix:"SMTP_"`
+	JWT      utils.JWTConfig     `envPrefix:"JWT_"`
+	Server   server.Config       `envPrefix:"SERVER_"`
+	Database databases.Config    `envPrefix:"DB_"`
 }
 
 // Load configs from .env file

--- a/internals/databases/db.go
+++ b/internals/databases/db.go
@@ -3,26 +3,22 @@ package databases
 import (
 	"fmt"
 	"log"
-	"os"
-	"strconv"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
-func NewDatabaseConnection() (*gorm.DB, error) {
-	host := os.Getenv("DB_HOST")
-	port, err := strconv.Atoi(os.Getenv("DB_PORT"))
-	if err != nil {
-		log.Fatal("failed to convert port to int")
-		return nil, err
-	}
-	user := os.Getenv("DB_USER")
-	password := os.Getenv("DB_PASSWORD")
-	dbname := os.Getenv("DB_NAME")
-	sslmode := os.Getenv("DB_SSLMODE")
+type Config struct {
+	Host     string `env:"HOST"`
+	Port     int    `env:"PORT"`
+	User     string `env:"USER"`
+	Password string `env:"PASSWORD"`
+	DBName   string `env:"NAME"`
+	SSLMode  string `env:"SSLMODE"`
+}
 
-	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s", host, port, user, password, dbname, sslmode)
+func NewDatabaseConnection(config Config) (*gorm.DB, error) {
+	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s", config.Host, config.Port, config.User, config.Password, config.DBName, config.SSLMode)
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 	if err != nil {
 		log.Fatal("failed to connect database")

--- a/internals/handlers/user_handler.go
+++ b/internals/handlers/user_handler.go
@@ -1,9 +1,9 @@
 package handlers
 
 import (
-	"github.com/PitiNarak/condormhub-backend/internals/config"
 	"github.com/PitiNarak/condormhub-backend/internals/core/domain"
 	"github.com/PitiNarak/condormhub-backend/internals/core/ports"
+	"github.com/PitiNarak/condormhub-backend/internals/core/utils"
 	"github.com/go-playground/validator"
 	"github.com/gofiber/fiber/v2"
 	"github.com/golang-jwt/jwt/v4"
@@ -13,10 +13,10 @@ import (
 type UserHandler struct {
 	UserService  ports.UserService
 	EmailService ports.EmailServicePort
-	Config       *config.AppConfig
+	Config       *utils.JWTConfig
 }
 
-func NewUserHandler(UserService ports.UserService, emailService ports.EmailServicePort, config *config.AppConfig) *UserHandler {
+func NewUserHandler(UserService ports.UserService, emailService ports.EmailServicePort, config *utils.JWTConfig) *UserHandler {
 	return &UserHandler{UserService: UserService, EmailService: emailService, Config: config}
 }
 
@@ -53,7 +53,7 @@ func (h *UserHandler) VerifyEmail(c *fiber.Ctx) error {
 	tokenString := c.Params("token")
 
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		return []byte(h.Config.JWT.JWTSecretKey), nil
+		return []byte(h.Config.JWTSecretKey), nil
 	})
 
 	if err != nil || !token.Valid {
@@ -125,7 +125,7 @@ func (h *UserHandler) ResetPasswordResponse(c *fiber.Ctx) error {
 	}
 
 	token, err := jwt.Parse(body.Token, func(token *jwt.Token) (interface{}, error) {
-		return []byte(h.Config.JWT.JWTSecretKey), nil
+		return []byte(h.Config.JWTSecretKey), nil
 	})
 	if err != nil || !token.Valid {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Invalid or expired token"})

--- a/internals/server/server.go
+++ b/internals/server/server.go
@@ -20,6 +20,7 @@ import (
 type Config struct {
 	Name                 string `env:"NAME"`
 	Port                 int    `env:"PORT"`
+	Env                  string `env:"ENV"`
 	MaxBodyLimitMB       int    `env:"MAX_BODY_LIMIT_MB"`
 	CorsAllowOrigins     string `env:"CORS_ALLOW_ORIGINS"`
 	CorsAllowMethods     string `env:"CORS_ALLOW_METHODS"`
@@ -73,6 +74,7 @@ func NewServer(config Config, smtpConfig services.SMTPConfig, jwtConfig utils.JW
 		greetingHandler:  handlers.NewGreetingHandler(),
 		sampleLogHandler: handlers.NewSampleLogHandler(sampleLogRepository),
 		userHandler:      userHandler,
+		config:           config,
 	}
 }
 


### PR DESCRIPTION
This pull request introduces several significant changes to the configuration management and server initialization processes. The main updates include the addition of server configuration parameters, refactoring of the database connection setup, and improvements to the server startup and shutdown logic.

### Configuration Management:
* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL8-R15): Added new server configuration parameters such as `SERVER_NAME`, `SERVER_PORT`, and CORS settings.
* [`internals/config/config.go`](diffhunk://#diff-6fcb8fbf408fbcdf0a2f402b0b22089a872bee5529766611bed800e688338d28R8-R18): Introduced `Server` and `Database` configuration structs to centralize configuration management.

### Database Connection:
* [`internals/databases/db.go`](diffhunk://#diff-7da07620b6646371e7a3d40d5a519ab6fd5e120827bb5da61e20896b1446e330L6-R21): Refactored the database connection function to use a configuration struct instead of environment variables.

### Server Initialization:
* [`cmd/server/main.go`](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eR4-R26): Enhanced server initialization to include context handling for graceful shutdown and updated the server start method to accept configuration parameters.
* [`internals/server/server.go`](diffhunk://#diff-debd3afe0533cd15967f63c915306324f84e899fd10026f3f087398d2b112b1eR4-R81): Added middleware for CORS, logging, and request ID, and improved error handling and shutdown procedures. [[1]](diffhunk://#diff-debd3afe0533cd15967f63c915306324f84e899fd10026f3f087398d2b112b1eR4-R81) [[2]](diffhunk://#diff-debd3afe0533cd15967f63c915306324f84e899fd10026f3f087398d2b112b1eL55-R111)

### Handler Updates:
* [`internals/handlers/user_handler.go`](diffhunk://#diff-358185d3ceb8d336489b4d4098284c59194a13a25eaf71f1c91cf11f7e6f64c9L4-R6): Updated the `UserHandler` to use the new `JWTConfig` struct and modified JWT parsing logic accordingly. [[1]](diffhunk://#diff-358185d3ceb8d336489b4d4098284c59194a13a25eaf71f1c91cf11f7e6f64c9L4-R6) [[2]](diffhunk://#diff-358185d3ceb8d336489b4d4098284c59194a13a25eaf71f1c91cf11f7e6f64c9L16-R19) [[3]](diffhunk://#diff-358185d3ceb8d336489b4d4098284c59194a13a25eaf71f1c91cf11f7e6f64c9L56-R56) [[4]](diffhunk://#diff-358185d3ceb8d336489b4d4098284c59194a13a25eaf71f1c91cf11f7e6f64c9L128-R128)