### PR TITLE
refactor: use token from header instead of body

### DIFF
--- a/internal/core/domain/handler_body.go
+++ b/internal/core/domain/handler_body.go
@@ -5,7 +5,6 @@ type ResetPasswordBody struct {
 }
 
 type ResponseResetPasswordBody struct {
-	Token    string `json:"token" validate:"required"`
 	Password string `json:"password" validate:"required"`
 }
 

--- a/internal/handlers/user_handler.go
+++ b/internal/handlers/user_handler.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"errors"
+
 	"github.com/PitiNarak/condormhub-backend/internal/core/domain"
 	"github.com/PitiNarak/condormhub-backend/internal/core/ports"
 	"github.com/PitiNarak/condormhub-backend/pkg/error_handler"
@@ -93,7 +95,10 @@ func (h *UserHandler) UpdateUserInformation(c *fiber.Ctx) error {
 }
 
 func (h *UserHandler) VerifyEmail(c *fiber.Ctx) error {
-	tokenString := c.Params("token")
+	tokenString := c.Get("token")
+	if tokenString == "" {
+		return error_handler.BadRequestError(errors.New("no token in header"), "your request header is incorrect")
+	}
 
 	if err := h.UserService.VerifyUser(tokenString); err != nil {
 		return error_handler.InternalServerError(err, "cannot verify your account")
@@ -134,8 +139,12 @@ func (h *UserHandler) ResetPasswordResponse(c *fiber.Ctx) error {
 	if err := validate.Struct(body); err != nil {
 		return error_handler.BadRequestError(err, "your request body is incorrect")
 	}
+	tokenString := c.Get("token")
+	if tokenString == "" {
+		return error_handler.BadRequestError(errors.New("no token in header"), "your request header is incorrect")
+	}
 
-	err := h.UserService.ResetPasswordResponse(body.Token, body.Password)
+	err := h.UserService.ResetPasswordResponse(tokenString, body.Password)
 	if err != nil {
 		return error_handler.InternalServerError(err, "cannot reset user password")
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -137,7 +137,7 @@ func (s *Server) initRoutes() {
 	userRoutes.Post("/register", s.userHandler.Create)
 	userRoutes.Post("/login", s.userHandler.Login)
 	userRoutes.Patch("/update", s.userHandler.UpdateUserInformation)
-	userRoutes.Get("/verify/:token", s.userHandler.VerifyEmail)
+	userRoutes.Get("/verify/", s.userHandler.VerifyEmail)
 	userRoutes.Get("/resetpassword", s.userHandler.ResetPasswordCreate)
 	userRoutes.Patch("/newpassword", s.userHandler.ResetPasswordResponse)
 }


### PR DESCRIPTION
## Description
As the name suggested, for every email service, we will use token from header instead of body

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Chore
- [x] Refactoring

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed (required)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated
- [ ] Tests passing
- [x] No new warnings

## Related Issues
Fixes #[issue_number]

## Notes
[Any additional context or concerns]
