### PR TITLE
Feat/check register email

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -18,6 +18,8 @@ func main() {
 		log.Fatalf("Database connection failed: %v", err)
 	}
 
+	db.Exec("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";")
+
 	if err := db.AutoMigrate(
 		&domain.SampleLog{},
 		&domain.User{},

--- a/internal/repositories/user_repository.go
+++ b/internal/repositories/user_repository.go
@@ -19,9 +19,9 @@ func NewUserRepo(db *gorm.DB) ports.UserRepository {
 
 func (r *UserRepo) Create(user *domain.User) error {
 
-	exitsUser := r.db.Model(&domain.User{}).Where("username = ?", user.Username).First(&domain.User{})
+	exitsUser := r.db.Model(&domain.User{}).Where("username = ?", user.Username).Or("email = ?", user.Email).First(&domain.User{})
 	if exitsUser.RowsAffected > 0 {
-		return error_handler.BadRequestError(nil, "username already exists")
+		return error_handler.BadRequestError(nil, "username already exists or email already exists")
 	}
 
 	err := r.db.Create(&user).Error


### PR DESCRIPTION
## Description
check before email or username already exits before create username without this it will send only "can't add user to db"

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Chore

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed (required)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated
- [ ] Tests passing
- [x] No new warnings

## Related Issues
Fixes #45 

## Notes
Additionally i add enable uuid extension in `cmd/migration/main.go`