### PR TITLE
fix: remove authentication middleware from new password route

### DIFF
--- a/internal/server/route.go
+++ b/internal/server/route.go
@@ -28,7 +28,7 @@ func (s *Server) initUserRoutes() {
 
 	userRoutes.Post("/verify", s.handler.user.VerifyEmail)
 	userRoutes.Post("/resetpassword", s.handler.user.ResetPasswordCreate)
-	userRoutes.Post("/newpassword", s.authMiddleware.Auth, s.handler.user.ResetPassword)
+	userRoutes.Post("/newpassword", s.handler.user.ResetPassword)
 	userRoutes.Patch("/", s.authMiddleware.Auth, s.handler.user.UpdateUserInformation)
 	userRoutes.Delete("/", s.authMiddleware.Auth, s.handler.user.DeleteAccount)
 }


### PR DESCRIPTION
## Description
remove authentication middleware from new password route

## Type of Change
Bug fix

## Checklist
- [x] run `golangci-lint`
- [x] No new warnings
- [x] Self-review completed
- [x] Documentation updated (checked it if no new handler added)
- [x] Tests passing

