### PR TITLE
fix: allow filter min price without max price

### DIFF
--- a/internal/handler/dorm_handler.go
+++ b/internal/handler/dorm_handler.go
@@ -167,7 +167,7 @@ func (d *DormHandler) GetAll(c *fiber.Ctx) error {
 	minPrice := c.QueryInt("minPrice", -1)
 	maxPrice := c.QueryInt("maxPrice", -1)
 
-	if minPrice > maxPrice {
+	if minPrice > maxPrice && minPrice != -1 && maxPrice != -1 {
 		err := errors.New("min price cannot more than max price")
 		return apperror.BadRequestError(err, err.Error())
 	}


### PR DESCRIPTION
## Description
Modified the min/max price check to allow only minPrice query param. To fix the issue where if only min price query is provided it will return "min price is more than max price" error.

## Type of Change
Bug fix

## Require Database Migration Before Merge ??
No

## Checklist
- [x] run `golangci-lint`
- [x] No new warnings
- [x] Self-review completed
- [x] Documentation updated (update and generate swagger)

## Related Issues (remove if empty)
Fixes #91 

## Notes
[Any additional context or concerns]
