### PR TITLE
Feat/count review dorm

### DIFF
--- a/internal/core/domain/leasing_history.go
+++ b/internal/core/domain/leasing_history.go
@@ -61,7 +61,7 @@ func (r *Review) ToDTO() dto.Review {
 func (l *LeasingHistory) AfterUpdate(tx *gorm.DB) (err error) {
 	// Calculate the new average rating after an update to leasingHistory
 	var avgRating float64
-	err = tx.Model(&LeasingHistory{}).Select("COALESCE(avg(rate), 0)").Where("dorm_id = ?", l.DormID).Scan(&avgRating).Error
+	err = tx.Model(&LeasingHistory{}).Select("COALESCE(avg(rate), 0)").Where("dorm_id = ?", l.DormID).Where("review_flag = ?", true).Scan(&avgRating).Error
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (l *LeasingHistory) AfterUpdate(tx *gorm.DB) (err error) {
 
 	// Count the amount of review a lessor has after an update to leasingHistory
 	var count int64
-	err = tx.Model(&LeasingHistory{}).Joins("JOIN dorms ON dorms.id = leasing_histories.dorm_id").Where("dorms.owner_id = ? AND review_flag = true", dorm.OwnerID).Count(&count).Error
+	err = tx.Model(&LeasingHistory{}).Joins("JOIN dorms ON dorms.id = leasing_histories.dorm_id").Where("dorms.owner_id = ?", dorm.OwnerID).Where("leasing_histories.review_flag = ?", true).Count(&count).Error
 	if err != nil {
 		return err
 	}

--- a/internal/core/domain/leasing_history.go
+++ b/internal/core/domain/leasing_history.go
@@ -94,3 +94,20 @@ func (l *LeasingHistory) AfterUpdate(tx *gorm.DB) (err error) {
 
 	return nil
 }
+
+func updateDormsLeasedCount(tx *gorm.DB, lesseeID uuid.UUID) error {
+	var count int64
+	if err := tx.Model(&LeasingHistory{}).Where("lessee_id = ?", lesseeID).Count(&count).Error; err != nil {
+		return err
+	}
+
+	if err := tx.Model(&User{}).Where("id = ?", lesseeID).Update("dorms_leased", count).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (l *LeasingHistory) AfterCreate(tx *gorm.DB) (err error) {
+	return updateDormsLeasedCount(tx, l.LesseeID)
+}

--- a/internal/core/domain/user.go
+++ b/internal/core/domain/user.go
@@ -200,5 +200,8 @@ func (u *User) ToDTO() dto.UserResponse {
 		Lifestyles:         lifestyles,
 		PhoneNumber:        u.PhoneNumber,
 		IsStudentVerified:  u.IsStudentVerified,
+		ReviewCount:        u.ReviewCount,
+		DormsOwned:         u.DormsOwned,
+		DormsLeased:        u.DormsLeased,
 	}
 }

--- a/internal/core/domain/user.go
+++ b/internal/core/domain/user.go
@@ -175,6 +175,9 @@ type User struct {
 	StudentEvidence    string
 	IsStudentVerified  bool `gorm:"default:false"`
 	ProfilePicKey      string
+	ReviewCount        int64 `gorm:"default:0"`
+	DormsOwned         int64 `gorm:"default:0"`
+	DormsLeased        int64 `gorm:"default:0"`
 }
 
 func (u *User) ToDTO() dto.UserResponse {

--- a/internal/core/ports/dorm_ports.go
+++ b/internal/core/ports/dorm_ports.go
@@ -15,7 +15,7 @@ type DormRepository interface {
 	GetAll(limit int, page int, search string, min_price int, max_price int, district string, subdistrict string, province string, zipcode string) ([]domain.Dorm, int, int, error)
 	GetByID(id uuid.UUID) (*domain.Dorm, error)
 	Update(id uuid.UUID, dorm dto.DormUpdateRequestBody) error
-	Delete(id uuid.UUID) error
+	Delete(dorm domain.Dorm) error
 	SaveDormImage(dormImage *domain.DormImage) error
 	GetByOwnerID(ownerID uuid.UUID, limit int, page int) ([]domain.Dorm, int, int, error)
 	DeleteImageByKey(imageKey string) error

--- a/internal/core/ports/leasing_history_ports.go
+++ b/internal/core/ports/leasing_history_ports.go
@@ -13,6 +13,7 @@ type LeasingHistoryRepository interface {
 	GetByID(id uuid.UUID) (*domain.LeasingHistory, error)
 	GetByUserID(id uuid.UUID, limit, page int) ([]domain.LeasingHistory, int, int, error)
 	GetByDormID(id uuid.UUID, limit, page int) ([]domain.LeasingHistory, int, int, error)
+	DeleteReview(leasingHistory *domain.LeasingHistory) error
 }
 
 type LeasingHistoryService interface {

--- a/internal/core/services/dorm_service.go
+++ b/internal/core/services/dorm_service.go
@@ -113,7 +113,7 @@ func (s *DormService) Delete(ctx context.Context, userID uuid.UUID, isAdmin bool
 		}
 	}
 
-	return s.dormRepo.Delete(dormID)
+	return s.dormRepo.Delete(*dorm)
 }
 
 func (s *DormService) UploadDormImage(ctx context.Context, dormID uuid.UUID, filename string, contentType string, fileData io.Reader, userID uuid.UUID, isAdmin bool) (string, error) {

--- a/internal/core/services/leasing_history_service.go
+++ b/internal/core/services/leasing_history_service.go
@@ -134,7 +134,7 @@ func (s *LeasingHistoryService) DeleteReview(user *domain.User, id uuid.UUID) er
 		return err
 	}
 	history.ReviewFlag = false
-	err = s.historyRepo.Update(history)
+	err = s.historyRepo.DeleteReview(history)
 	if err != nil {
 		return err
 	}

--- a/internal/dto/user_body.go
+++ b/internal/dto/user_body.go
@@ -67,6 +67,9 @@ type UserResponse struct {
 	PhoneNumber        string    `json:"phoneNumber"`
 	IsStudentVerified  bool      `json:"isStudentVerified"`
 	ProfilePicUrl      string    `json:"profilePicUrl"`
+	ReviewCount        int64     `json:"review_count"`
+	DormsOwned         int64     `json:"dorms_owned"`
+	DormsLeased        int64     `gorm:"dorms_leased"`
 }
 
 type StudentEvidenceUploadResponseBody struct {

--- a/internal/repository/dorm_repository.go
+++ b/internal/repository/dorm_repository.go
@@ -24,9 +24,9 @@ func (d *DormRepository) Create(dorm *domain.Dorm) error {
 	return nil
 }
 
-func (d *DormRepository) Delete(id uuid.UUID) error {
+func (d *DormRepository) Delete(dorm domain.Dorm) error {
 	// TODO: Cascade delete for all field that reference to dorm
-	if err := d.db.Select("Images").Delete(&domain.Dorm{ID: id}).Error; err != nil {
+	if err := d.db.Select("Images").Delete(&dorm).Error; err != nil {
 		return apperror.InternalServerError(err, "Failed to delete dorm")
 	}
 	return nil

--- a/internal/repository/leasing_history_repository.go
+++ b/internal/repository/leasing_history_repository.go
@@ -55,14 +55,17 @@ func (d *LeasingHistoryRepository) Update(LeasingHistory *domain.LeasingHistory)
 		}
 		return apperror.InternalServerError(err, "Failed to update leasing history")
 	}
-	if existingHistory.ReviewFlag != LeasingHistory.ReviewFlag {
-		err = d.db.Model(existingHistory).UpdateColumn("ReviewFlag", LeasingHistory.ReviewFlag).Error
-		if err != nil {
-			return err
-		}
+	return nil
+}
+
+func (d *LeasingHistoryRepository) DeleteReview(leasingHistory *domain.LeasingHistory) error {
+	err := d.db.Model(leasingHistory).Update("review_flag", false).Error
+	if err != nil {
+		return apperror.InternalServerError(err, "Failed to delete review")
 	}
 	return nil
 }
+
 func (d *LeasingHistoryRepository) Delete(id uuid.UUID) error {
 	// TODO: Cascade delete?
 	if err := d.db.Delete(&domain.LeasingHistory{}, id).Error; err != nil {


### PR DESCRIPTION
## Description
Implement trigger for the following:
1. Counting the amount of Review a Lessor has across all their different dorms. Trigger activate after an update happen on LeasingHistory
2. Counting the amount of Dorms a Lessor has. Trigger activate after a Dorm is created/deleted.
3. Counting the amount of Dorms a Lessee has ever leased. Trigger activate after a LeasingHistory is created only.

## Type of Change
New feature

## Require Database Migration Before Merge ??
Yes

## Checklist
- [x] run `golangci-lint`
- [x] No new warnings
- [x] Self-review completed
- [x] Documentation updated (update and generate swagger)

## Notes
This pr is for the feature requested by porsche for fields he wants to show on users' profile page
