### PR TITLE
Feat/student verification

### DIFF
--- a/internal/core/domain/user.go
+++ b/internal/core/domain/user.go
@@ -182,7 +182,6 @@ type User struct {
 	PhoneNumber        string
 	StudentEvidence    string
 	IsStudentVerified  VerificationStatus
-	ReviewedDate       time.Time `gorm:"type:DATE;default:null"`
 	ProfilePicKey      string
 	ReviewCount        int64 `gorm:"default:0"`
 	DormsOwned         int64 `gorm:"default:0"`

--- a/internal/core/domain/user.go
+++ b/internal/core/domain/user.go
@@ -155,6 +155,14 @@ func (l LifestyleArray) Value() (driver.Value, error) {
 	// return string(jsonData), nil
 }
 
+type VerificationStatus string
+
+const (
+	StatusPending  VerificationStatus = "PENDING"
+	StatusVerified VerificationStatus = "VERIFIED"
+	StatusRejected VerificationStatus = "REJECTED"
+)
+
 type User struct {
 	ID                 uuid.UUID `gorm:"type:uuid;default:uuid_generate_v4();primaryKey"`
 	CreateAt           time.Time `gorm:"autoCreateTime"`
@@ -173,7 +181,8 @@ type User struct {
 	Lifestyles         LifestyleArray `validate:"lifestyle" gorm:"type:lifestyle_tag[]"`
 	PhoneNumber        string
 	StudentEvidence    string
-	IsStudentVerified  bool `gorm:"default:false"`
+	IsStudentVerified  VerificationStatus
+	ReviewedDate       time.Time `gorm:"type:DATE;default:null"`
 	ProfilePicKey      string
 	ReviewCount        int64 `gorm:"default:0"`
 	DormsOwned         int64 `gorm:"default:0"`
@@ -200,7 +209,7 @@ func (u *User) ToDTO() dto.UserResponse {
 		FilledPersonalInfo: u.FilledPersonalInfo,
 		Lifestyles:         lifestyles,
 		PhoneNumber:        u.PhoneNumber,
-		IsStudentVerified:  u.IsStudentVerified,
+		IsStudentVerified:  string(u.IsStudentVerified),
 		ReviewCount:        u.ReviewCount,
 		DormsOwned:         u.DormsOwned,
 		DormsLeased:        u.DormsLeased,

--- a/internal/core/ports/user_port.go
+++ b/internal/core/ports/user_port.go
@@ -18,7 +18,7 @@ type UserRepository interface {
 	GetUserByEmail(email string) (*domain.User, error)
 	DeleteAccount(userID uuid.UUID) error
 	GetLessorIncome(lessorID uuid.UUID) (float64, error)
-	GetPending() ([]domain.User, error)
+	GetPending(limit int, page int) ([]domain.User, int, int, error)
 }
 
 type UserService interface {
@@ -41,7 +41,7 @@ type UserService interface {
 	UploadProfilePicture(ctx context.Context, filename string, contentType string, fileData io.Reader, userID uuid.UUID) (string, error)
 	GetLessorIncome(lessorID uuid.UUID, userRole domain.Role) (float64, error)
 	UpdateUserBanStatus(id uuid.UUID, ban bool) (*domain.User, error)
-	GetPending() ([]domain.User, error)
+	GetPending(limit int, page int) ([]domain.User, int, int, error)
 }
 
 type UserHandler interface {

--- a/internal/core/ports/user_port.go
+++ b/internal/core/ports/user_port.go
@@ -18,6 +18,7 @@ type UserRepository interface {
 	GetUserByEmail(email string) (*domain.User, error)
 	DeleteAccount(userID uuid.UUID) error
 	GetLessorIncome(lessorID uuid.UUID) (float64, error)
+	GetPending() ([]domain.User, error)
 }
 
 type UserService interface {
@@ -39,6 +40,7 @@ type UserService interface {
 	UploadProfilePicture(ctx context.Context, filename string, contentType string, fileData io.Reader, userID uuid.UUID) (string, error)
 	GetLessorIncome(lessorID uuid.UUID, userRole domain.Role) (float64, error)
 	UpdateUserBanStatus(id uuid.UUID, ban bool) (*domain.User, error)
+	GetPending() ([]domain.User, error)
 }
 
 type UserHandler interface {
@@ -60,4 +62,5 @@ type UserHandler interface {
 	GetLessorIncome(c *fiber.Ctx) error
 	BanUser(c *fiber.Ctx) error
 	UnbanUser(c *fiber.Ctx) error
+	GetPending(c *fiber.Ctx) error
 }

--- a/internal/core/ports/user_port.go
+++ b/internal/core/ports/user_port.go
@@ -23,6 +23,7 @@ type UserRepository interface {
 
 type UserService interface {
 	ConvertToDTO(user domain.User) dto.UserResponse
+	GetStudentEvidenceDTO(c context.Context, studentEvidence string) (*dto.StudentEvidenceUploadResponseBody, error)
 	Create(ctx context.Context, user *domain.User) (string, string, error)
 	GetUserByEmail(email string) (*domain.User, error)
 	GetUserByID(id uuid.UUID) (*domain.User, error)

--- a/internal/core/ports/user_port.go
+++ b/internal/core/ports/user_port.go
@@ -42,6 +42,7 @@ type UserService interface {
 	GetLessorIncome(lessorID uuid.UUID, userRole domain.Role) (float64, error)
 	UpdateUserBanStatus(id uuid.UUID, ban bool) (*domain.User, error)
 	GetPending(limit int, page int) ([]domain.User, int, int, error)
+	UpdateVerificationStatus(lesseeID uuid.UUID, status domain.VerificationStatus) (*domain.User, error)
 }
 
 type UserHandler interface {
@@ -64,4 +65,6 @@ type UserHandler interface {
 	BanUser(c *fiber.Ctx) error
 	UnbanUser(c *fiber.Ctx) error
 	GetPending(c *fiber.Ctx) error
+	VerifyStudentVerification(c *fiber.Ctx) error
+	RejectStudentVerification(c *fiber.Ctx) error
 }

--- a/internal/core/services/user_service.go
+++ b/internal/core/services/user_service.go
@@ -418,6 +418,6 @@ func (s *UserService) UpdateUserBanStatus(id uuid.UUID, ban bool) (*domain.User,
 	return user, s.userRepo.UpdateUser(user)
 }
 
-func (s *UserService) GetPending() ([]domain.User, error) {
-	return s.userRepo.GetPending()
+func (s *UserService) GetPending(limit int, page int) ([]domain.User, int, int, error) {
+	return s.userRepo.GetPending(limit, page)
 }

--- a/internal/core/services/user_service.go
+++ b/internal/core/services/user_service.go
@@ -421,3 +421,17 @@ func (s *UserService) UpdateUserBanStatus(id uuid.UUID, ban bool) (*domain.User,
 func (s *UserService) GetPending(limit int, page int) ([]domain.User, int, int, error) {
 	return s.userRepo.GetPending(limit, page)
 }
+
+func (s *UserService) UpdateVerificationStatus(lesseeID uuid.UUID, status domain.VerificationStatus) (*domain.User, error) {
+	lessee, err := s.userRepo.GetUserByID(lesseeID)
+	if err != nil {
+		return nil, err
+	}
+
+	if lessee.IsStudentVerified != domain.StatusPending {
+		return nil, apperror.ConflictError(errors.New("verification not pending"), "verification not pending")
+	}
+
+	lessee.IsStudentVerified = status
+	return lessee, s.userRepo.UpdateUser(lessee)
+}

--- a/internal/core/services/user_service.go
+++ b/internal/core/services/user_service.go
@@ -413,3 +413,7 @@ func (s *UserService) UpdateUserBanStatus(id uuid.UUID, ban bool) (*domain.User,
 	user.Banned = ban
 	return user, s.userRepo.UpdateUser(user)
 }
+
+func (s *UserService) GetPending() ([]domain.User, error) {
+	return s.userRepo.GetPending()
+}

--- a/internal/core/services/user_service.go
+++ b/internal/core/services/user_service.go
@@ -309,6 +309,7 @@ func (s *UserService) UploadStudentEvidence(ctx context.Context, filename string
 	}
 
 	user.StudentEvidence = fileKey
+	user.IsStudentVerified = domain.StatusPending
 	err = s.userRepo.UpdateUser(user)
 	if err != nil {
 		return "", err

--- a/internal/dto/user_body.go
+++ b/internal/dto/user_body.go
@@ -65,7 +65,8 @@ type UserResponse struct {
 	FilledPersonalInfo bool      `json:"filledPersonalInfo"`
 	Lifestyles         []string  `json:"lifestyles"`
 	PhoneNumber        string    `json:"phoneNumber"`
-	IsStudentVerified  bool      `json:"isStudentVerified"`
+	IsStudentVerified  string    `json:"isStudentVerified"`
+	ReviewedData       time.Time `json:"reviewed_date"`
 	ProfilePicUrl      string    `json:"profilePicUrl"`
 	ReviewCount        int64     `json:"review_count"`
 	DormsOwned         int64     `json:"dorms_owned"`

--- a/internal/dto/user_body.go
+++ b/internal/dto/user_body.go
@@ -66,7 +66,6 @@ type UserResponse struct {
 	Lifestyles         []string  `json:"lifestyles"`
 	PhoneNumber        string    `json:"phoneNumber"`
 	IsStudentVerified  string    `json:"isStudentVerified"`
-	ReviewedData       time.Time `json:"reviewed_date"`
 	ProfilePicUrl      string    `json:"profilePicUrl"`
 	ReviewCount        int64     `json:"review_count"`
 	DormsOwned         int64     `json:"dorms_owned"`
@@ -85,4 +84,9 @@ type ProfilePictureUploadResponseBody struct {
 
 type LessorIncomeResponseBody struct {
 	Income float64 `json:"income"`
+}
+
+type StudentEvidenceResponse struct {
+	User     UserResponse                      `json:"user"`
+	Evidence StudentEvidenceUploadResponseBody `json:"evidence"`
 }

--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -682,6 +682,20 @@ func (h *UserHandler) UnbanUser(c *fiber.Ctx) error {
 	return c.Status(fiber.StatusOK).JSON(dto.Success(updatedUser.ToDTO()))
 }
 
+// GetPending godoc
+// @Summary Get all pending student verifications
+// @Description Get all pending student verifications
+// @Tags admin
+// @Security Bearer
+// @Produce json
+// @Param limit query int false "Number of pending verification to retrieve (default 10, max 50)"
+// @Param page query int false "Page number to retrieve (default 1)"
+// @Success 200 {object} dto.PaginationResponse[dto.StudentEvidenceResponse] "All pending verification retrieved"
+// @Failure 401 {object} dto.ErrorResponse "unauthorized"
+// @Failure 403 {object} dto.ErrorResponse "forbidden"
+// @Failure 404 {object} dto.ErrorResponse "not found"
+// @Failure 500 {object} dto.ErrorResponse "internal server error"
+// @Router /admin/lessee/pending [get]
 func (h *UserHandler) GetPending(c *fiber.Ctx) error {
 	limit := c.QueryInt("limit", 10)
 	if limit <= 0 {

--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -681,3 +681,23 @@ func (h *UserHandler) UnbanUser(c *fiber.Ctx) error {
 
 	return c.Status(fiber.StatusOK).JSON(dto.Success(updatedUser.ToDTO()))
 }
+
+func (h *UserHandler) GetPending(c *fiber.Ctx) error {
+	pendings, err := h.userService.GetPending()
+	if err != nil {
+		return err
+	}
+
+	res := make([]dto.StudentEvidenceResponse, len(pendings))
+	for i, pending := range pendings {
+		res[i].User = h.userService.ConvertToDTO(pending)
+
+		evidence, err := h.userService.GetStudentEvidenceDTO(c.Context(), pending.StudentEvidence)
+		if err != nil {
+			return err
+		}
+		res[i].Evidence = *evidence
+	}
+
+	return c.Status(fiber.StatusOK).JSON(dto.Success(res))
+}

--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -764,10 +764,40 @@ func (h *UserHandler) ReviewStudentVerification(c *fiber.Ctx, status domain.Veri
 	return c.Status(fiber.StatusOK).JSON(dto.Success(data))
 }
 
+// VerifyStudentVerification godoc
+// @Summary Verify a lessee student verification
+// @Description Verify a lessee student verification
+// @Tags admin
+// @Security Bearer
+// @Produce json
+// @Param id path string true "lesseeID"
+// @Success 200 {object} dto.SuccessResponse[dto.StudentEvidenceResponse] "Lessee verified"
+// @Failure 400 {object} dto.ErrorResponse "bad request"
+// @Failure 401 {object} dto.ErrorResponse "unauthorized"
+// @Failure 403 {object} dto.ErrorResponse "forbidden"
+// @Failure 404 {object} dto.ErrorResponse "not found"
+// @Failure 409 {object} dto.ErrorResponse "confilct"
+// @Failure 500 {object} dto.ErrorResponse "internal server error"
+// @Router /admin/lessee/{id}/verify [patch]
 func (h *UserHandler) VerifyStudentVerification(c *fiber.Ctx) error {
 	return h.ReviewStudentVerification(c, domain.StatusVerified)
 }
 
+// RejectStudentVerification godoc
+// @Summary Reject a lessee student verification
+// @Description Reject a lessee student verification
+// @Tags admin
+// @Security Bearer
+// @Produce json
+// @Param id path string true "lesseeID"
+// @Success 200 {object} dto.SuccessResponse[dto.StudentEvidenceResponse] "Lessee rejected"
+// @Failure 400 {object} dto.ErrorResponse "bad request"
+// @Failure 401 {object} dto.ErrorResponse "unauthorized"
+// @Failure 403 {object} dto.ErrorResponse "forbidden"
+// @Failure 404 {object} dto.ErrorResponse "not found"
+// @Failure 409 {object} dto.ErrorResponse "confilct"
+// @Failure 500 {object} dto.ErrorResponse "internal server error"
+// @Router /admin/lessee/{id}/reject [patch]
 func (h *UserHandler) RejectStudentVerification(c *fiber.Ctx) error {
 	return h.ReviewStudentVerification(c, domain.StatusRejected)
 }

--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -449,6 +449,7 @@ func (h *UserHandler) GetUserByID(c *fiber.Ctx) error {
 // @Success 200 {object} dto.SuccessResponse[dto.StudentEvidenceUploadResponseBody] "Evidence uploaded successfully"
 // @Failure 400 {object} dto.ErrorResponse "File is required"
 // @Failure 401 {object} dto.ErrorResponse "your request is unauthorized"
+// @Failure 403 {object} dto.ErrorResponse "forbidden"
 // @Failure 404 {object} dto.ErrorResponse "User not found"
 // @Failure 500 {object} dto.ErrorResponse "Server failed to upload file"
 // @Router /user/studentEvidence [post]

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -92,3 +92,11 @@ func (r *UserRepo) GetLessorIncome(lessorID uuid.UUID) (float64, error) {
 	}
 	return income, nil
 }
+
+func (r *UserRepo) GetPending() ([]domain.User, error) {
+	var pending []domain.User
+	if err := r.db.Where("is_student_verified = ?", domain.StatusPending).Find(pending).Error; err != nil {
+		return nil, apperror.InternalServerError(err, "Failed to load lessee with pending verification")
+	}
+	return pending, nil
+}

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -93,10 +93,13 @@ func (r *UserRepo) GetLessorIncome(lessorID uuid.UUID) (float64, error) {
 	return income, nil
 }
 
-func (r *UserRepo) GetPending() ([]domain.User, error) {
+func (r *UserRepo) GetPending(limit int, page int) ([]domain.User, int, int, error) {
 	var pending []domain.User
-	if err := r.db.Where("is_student_verified = ?", domain.StatusPending).Find(pending).Error; err != nil {
-		return nil, apperror.InternalServerError(err, "Failed to load lessee with pending verification")
+	query := r.db.Where("is_student_verified = ?", domain.StatusPending)
+
+	totalPages, totalRows, err := r.db.Paginate(pending, query, limit, page, "update_at DESC")
+	if err != nil {
+		return nil, 0, 0, apperror.InternalServerError(err, "Failed to load lessee with pending verification")
 	}
-	return pending, nil
+	return pending, totalPages, totalRows, nil
 }

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -97,7 +97,7 @@ func (r *UserRepo) GetPending(limit int, page int) ([]domain.User, int, int, err
 	var pending []domain.User
 	query := r.db.Where("is_student_verified = ?", domain.StatusPending)
 
-	totalPages, totalRows, err := r.db.Paginate(pending, query, limit, page, "update_at DESC")
+	totalPages, totalRows, err := r.db.Paginate(&pending, query, limit, page, "update_at DESC")
 	if err != nil {
 		return nil, 0, 0, apperror.InternalServerError(err, "Failed to load lessee with pending verification")
 	}

--- a/internal/server/route.go
+++ b/internal/server/route.go
@@ -150,4 +150,5 @@ func (s *Server) initAdminRoutes() {
 	adminRoutes := s.app.Group("/admin", s.authMiddleware.Auth, s.authMiddleware.RequireAdmin)
 	adminRoutes.Patch("/user/:id/ban", s.handler.user.BanUser)
 	adminRoutes.Patch("/user/:id/unban", s.handler.user.UnbanUser)
+	adminRoutes.Get("/lessee/pending", s.handler.user.GetPending)
 }

--- a/internal/server/route.go
+++ b/internal/server/route.go
@@ -151,4 +151,6 @@ func (s *Server) initAdminRoutes() {
 	adminRoutes.Patch("/user/:id/ban", s.handler.user.BanUser)
 	adminRoutes.Patch("/user/:id/unban", s.handler.user.UnbanUser)
 	adminRoutes.Get("/lessee/pending", s.handler.user.GetPending)
+	adminRoutes.Patch("/lessee/:id/verify", s.handler.user.VerifyStudentVerification)
+	adminRoutes.Patch("/lessee/:id/reject", s.handler.user.RejectStudentVerification)
 }


### PR DESCRIPTION
## Description
Implement endpoint for admin to get all lessee that has pending student verification status and their student evidence.
Implement endpoint for admin to verify and reject lessee' student evidence.

Automatically change student verification status to pending when a lessee upload a student evidence.
Add status check to endpoint for uploading student evidence, to not allow lessee that has already been verified to upload again.

## Type of Change
New feature

## Require Database Migration Before Merge ??
Yes

## Checklist
- [x] run `golangci-lint`
- [x] No new warnings
- [x] Self-review completed
- [x] Documentation updated (update and generate swagger)

## Notes
[Any additional context or concerns]
